### PR TITLE
EQxxを本来の数式に置換する際、正規表現を使うように変更

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ function resetTextbox() {
 function runTranslation() {
     const API_URL = 'https://api-free.deepl.com/v2/translate';
 
-    let substi_sets = {pre:"EQ", pre_small:"eq", len_num: 2, cnt: 0};
+    let substi_sets = {pre:"EQ", len_num: 2, cnt: 0};
 
     let equation_list = [];
 
@@ -108,11 +108,9 @@ function runTranslation() {
 
             goOutputSection();
 
+            // Texでの出力
             const editor = ace.edit("editor")
             editor.setValue("")
-            // editor.session.insert(
-            //     editor.selection.getCursor(), translation_result
-            // );
             editor.setValue(changeEquationForTexOutput(translation_result))
 
         }).catch(function(error) {
@@ -370,11 +368,7 @@ function replaceSubstiWithEquation(translation_result, equation_list, substi_set
 
         equation = equation_list[i];
 
-        substi = substi_sets.pre + String(i).padStart(substi_sets.len_num, '0');
-        translation_result = translation_result.replace(substi, equation);
-
-        // たまに翻訳によって，"EQxxxx"から"eqxxxx"になることがあるので．
-        substi = substi_sets.pre_small + String(i).padStart(substi_sets.len_num, '0');
+        substi = new RegExp(substi_sets.pre + String(i).padStart(substi_sets.len_num, '0'), "ig");
         translation_result = translation_result.replace(substi, equation);
     }
 


### PR DESCRIPTION
EQxxを本来の数式に置換するとき、正規表現を使うように変更した

それにより、
- 入力された文章が途中で切れている場合、翻訳結果の文章中に同じEQxxが2つ以上発生することで、生じるバグを防いだ
- また、DeepLによって翻訳されるとEQがeqになることがあり、その場合の処理を別で書いていたが、その必要がなくなった