### PR TITLE
replace()の第二引数にドルが入る場合の書き方を正した

### DIFF
--- a/main.js
+++ b/main.js
@@ -281,7 +281,7 @@ function changeEquationForMathjax(equation, is_inline_eq) {
 
 function changeEquationForTexOutput(outputForMathjax) {
 
-    let outputForTex = outputForMathjax.replace(/\\\(/g, '\$').replace(/\\\)/g, '\$').replace(/\\\[/g, "\$\$\$").replace(/\\\]/g, "\$\$\$");
+    let outputForTex = outputForMathjax.replace(/\\\(/g, '$$').replace(/\\\)/g, '$$').replace(/\\\[/g, "$$$$").replace(/\\\]/g, "$$$$");
 
     return outputForTex
 


### PR DESCRIPTION
replace()の第二引数にドルが入る場合の書き方を正した