### PR TITLE
Fixed the program to retain the period in the equation when ‘right’ precedes it at the end of the formula.

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,7 +234,8 @@ function replaceEquationWithSubsti(equation, is_inline_eq, substi_sets) {
     } else {
 
         // 数式の末尾にカンマ・ピリオドがある場合のみ，それを数式の外に出す．
-        idx_punc = equation.search(/(\.|,|;)\s*\\]/);
+        // ただし、文末が\right. のときのみ、外には出さない。
+        idx_punc = equation.search(/(?<!\\right\s*)(\.|,|;)\s*\\]/);
         no_end_punc = (idx_punc == -1);
 
         substi = getSubstiString(substi_sets);


### PR DESCRIPTION
数式の末尾のピリオドの前に"right"があると、ピリオドを数式から出さないようプログラムを修正した